### PR TITLE
Create function to get if the user is trying to interact with the debugUI

### DIFF
--- a/debugui.go
+++ b/debugui.go
@@ -24,3 +24,7 @@ func (d *DebugUI) Update(f func(ctx *Context)) {
 func (d *DebugUI) Draw(screen *ebiten.Image) {
 	d.ctx.draw(screen)
 }
+
+func (d *DebugUI) IsCapturingInput() bool {
+	return d.ctx.hoverRoot != nil || d.ctx.focus != 0
+}


### PR DESCRIPTION
This mostly works well so far  to resolve the issue I opened a few days ago #13 

I don't know if this is what you had in mind for this library so don't feel obligated to merge this quickly if this isn't what you want. I don't know if this works in all cases but from a few minutes of my testing it seems to work in all the cases I need it to. 

My intent is to declare a variable equal to the value returned from WantsInput() to be able to check if you are trying to interact with the debugUI or the game itself. If true you can skip over handling input in your game. Also it's optional to call if someone doesn't want to block input or only block certain kinds of input. 

This only handles keyboard and mouse as I have not dealt with a gamepad at all in my own development yet. I don't know if it would work with that. 