### PR TITLE
Update InputCapturingStateHover calculation to support collapsed panels

### DIFF
--- a/context.go
+++ b/context.go
@@ -96,7 +96,11 @@ func (c *Context) update(f func(ctx *Context) error) (inputCapturingState InputC
 	// Check whether the cursor is on any of the root containers.
 	pt := c.pointingPosition()
 	for _, cnt := range c.rootContainers {
-		if pt.In(cnt.layout.Bounds) {
+		bounds := cnt.layout.Bounds
+		if cnt.collapsed {
+			bounds.Max.Y -= cnt.layout.BodyBounds.Dy()
+		}
+		if pt.In(bounds) {
 			inputCapturingState |= InputCapturingStateHover
 		}
 	}

--- a/context.go
+++ b/context.go
@@ -98,7 +98,7 @@ func (c *Context) update(f func(ctx *Context) error) (inputCapturingState InputC
 	for _, cnt := range c.rootContainers {
 		bounds := cnt.layout.Bounds
 		if cnt.collapsed {
-			bounds.Max.Y -= cnt.layout.BodyBounds.Dy()
+			bounds.Max.Y = cnt.layout.BodyBounds.Min.Y
 		}
 		if pt.In(bounds) {
 			inputCapturingState |= InputCapturingStateHover


### PR DESCRIPTION
Resolves #34 by updating InputCapturingStateHover calculation to support collapsed panels.

---

This PR fixes an issue where `InputCapturingStateHover` could still be returned for a collapsed window.

## Problem

When a debug UI window is collapsed, the full `layout.Bounds` was still being checked for pointer containment. This meant that even when only the title bar was visible, `InputCapturingStateHover` would be set if the pointer was anywhere in the (now-hidden) body area.

## Fix

* When a container is collapsed, we now calculate a `collapsedBounds` rectangle that excludes the body area by subtracting `BodyBounds.Dy()` from the bottom of the window.
* We use this `collapsedBounds` to determine whether the pointer is hovering over a collapsed window’s visible area (i.e. just the title bar).
* This ensures `InputCapturingStateHover` reflects only what is actually visible.