### PR TITLE
debugui: add an example to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,18 +20,20 @@ import (
 	"github.com/hajimehoshi/ebiten/v2"
 )
 
+const loopCount = 10
+
 type Game struct {
 	debugui debugui.DebugUI // Place a debugui instance on your Game
 }
 
 func (g *Game) Update() error {
 	if _, err := g.debugui.Update(func(ctx *debugui.Context) error {
-		ctx.Window("Debugui Window", image.Rect(0, 0, 640, 400), func(layout debugui.ContainerLayout) {
+		ctx.Window("Debugui Window", image.Rect(0, 0, 320, 240), func(layout debugui.ContainerLayout) {
 			// Place all your widgets inside a ctx.Window
 			ctx.Text("Some text")
 
-			// If you ever need to make loop to make widgets, use ctx.Loop
-			loopCount := 10
+			// If you ever need to make a loop to make widgets, use ctx.Loop
+
 			ctx.Loop(loopCount, func(index int) {
 				ctx.Text(fmt.Sprintf("Index value is %d", index))
 			})

--- a/README.md
+++ b/README.md
@@ -8,6 +8,57 @@ DebugUI is a UI toolkit for Ebitengine applications, primarily intended for debu
 
 DebugUI is based on [Microui](https://github.com/rxi/microui). The original Microui was developed by [@rxi](https://github.com/rxi/microui). The original Go port was developed by [@zeozeozeo](https://github.com/zeozeozeo) and [@Zyko0](https://github.com/Zyko0).
 
+## Example go file
+```go
+package main
+
+import (
+	"fmt"
+	"image"
+
+	"github.com/ebitengine/debugui"
+	"github.com/hajimehoshi/ebiten/v2"
+)
+
+type Game struct {
+	debugui debugui.DebugUI // Place a debugui instance on your Game
+}
+
+func (g *Game) Update() error {
+	if _, err := g.debugui.Update(func(ctx *debugui.Context) error {
+		ctx.Window("Debugui Window", image.Rect(0, 0, 640, 400), func(layout debugui.ContainerLayout) {
+			// Place all your widgets inside a ctx.Window
+			ctx.Text("Some text")
+
+			// If you ever need to make loop to make widgets, use ctx.Loop
+			loopCount := 10
+			ctx.Loop(loopCount, func(index int) {
+				ctx.Text(fmt.Sprintf("Index value is %d", index))
+			})
+		})
+		return nil
+	}); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (g *Game) Draw(screen *ebiten.Image) {
+	g.debugui.Draw(screen) // Draw debugui at the end
+}
+
+func (g *Game) Layout(outsideWidth, outsideHeight int) (screenWidth, screenHeight int) {
+	return outsideWidth, outsideHeight
+}
+
+func main() {
+	game := &Game{}
+	if err := ebiten.RunGame(game); err != nil {
+		panic(err)
+	}
+}
+```
+
 ## License
 
 DebugUI for Ebitengine is licensed under Apache license version 2.0. See [LICENSE](LICENSE) file.


### PR DESCRIPTION
Adding this example makes it easier for new users to quickly understand how to use the library, also provides an example of ctx.Loop which i belive is crucial