### PR TITLE
fix: place text field caret at end of preloaded text

### DIFF
--- a/textfield.go
+++ b/textfield.go
@@ -11,6 +11,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/hajimehoshi/ebiten/v2"
+	"github.com/hajimehoshi/ebiten/v2/exp/textinput"
 	"github.com/hajimehoshi/ebiten/v2/inpututil"
 )
 
@@ -41,8 +42,12 @@ func (c *Context) textFieldRaw(buf *string, id widgetID, opt option) (EventHandl
 
 		f := c.currentContainer().textInputTextField(id, true)
 		if c.focus == id {
+			// A freshly focused text input field still has its own cursor/selection state.
+			// Seed that state from the bound string before reading input so typing starts
+			// after any existing text instead of inserting at the beginning.
+			focusTextInputField(f, *buf)
+
 			// handle text input
-			f.Focus()
 			x := bounds.Min.X + c.style().padding + textWidth(*buf)
 			y := bounds.Min.Y + lineHeight()
 			handled, err := f.HandleInput(x, y)
@@ -58,7 +63,7 @@ func (c *Context) textFieldRaw(buf *string, id widgetID, opt option) (EventHandl
 				if inpututil.IsKeyJustPressed(ebiten.KeyBackspace) && len(*buf) > 0 {
 					_, size := utf8.DecodeLastRuneInString(*buf)
 					*buf = (*buf)[:len(*buf)-size]
-					f.SetTextAndSelection(*buf, len(*buf), len(*buf))
+					setTextInputFieldValue(f, *buf)
 				}
 				if inpututil.IsKeyJustPressed(ebiten.KeyEnter) {
 					e = &eventHandler{}
@@ -66,7 +71,9 @@ func (c *Context) textFieldRaw(buf *string, id widgetID, opt option) (EventHandl
 			}
 		} else {
 			if *buf != f.Text() {
-				f.SetTextAndSelection(*buf, len(*buf), len(*buf))
+				// Keep the cached text-input object in sync while it is unfocused so the
+				// next focus starts from the latest value and with the caret at the end.
+				setTextInputFieldValue(f, *buf)
 			}
 			if wasFocused {
 				e = &eventHandler{}
@@ -100,13 +107,35 @@ func (c *Context) textFieldRaw(buf *string, id widgetID, opt option) (EventHandl
 	})
 }
 
+func focusTextInputField(f *textinput.Field, value string) {
+	// Focus() does not rewrite the field's text or selection. If this field is being
+	// focused for the first time, its selection is still 0,0, so copy in the current
+	// value first and move the caret to the end.
+	//
+	// Reset the selection on every unfocused->focused transition, even when the
+	// text already matches. The cached textinput.Field can survive across window
+	// reopenings, and in that case it can keep an old caret position from an
+	// earlier edit session.
+	if !f.IsFocused() {
+		setTextInputFieldValue(f, value)
+	}
+	f.Focus()
+}
+
+func setTextInputFieldValue(f *textinput.Field, value string) {
+	// Treat programmatic value changes the same way a user expects to keep typing:
+	// after loading text, place the caret at the end ready for appending.
+	f.SetTextAndSelection(value, len(value), len(value))
+}
+
 // SetTextFieldValue sets the value of the current text field.
+// The caret is moved to the end of the new text.
 //
 // If the last widget is not a text field, this function does nothing.
 func (c *Context) SetTextFieldValue(value string) {
 	_ = c.wrapEventHandlerAndError(func() (EventHandler, error) {
 		if f := c.currentContainer().textInputTextField(c.currentID, false); f != nil {
-			f.SetTextAndSelection(value, 0, 0)
+			setTextInputFieldValue(f, value)
 		}
 		return nil, nil
 	})
@@ -201,7 +230,7 @@ func (c *Context) numberField(value *int, step int, idPart string, opt option) (
 				if updated {
 					buf := fmt.Sprintf("%d", *value)
 					if f := c.currentContainer().textInputTextField(id, false); f != nil {
-						f.SetTextAndSelection(buf, len(buf), len(buf))
+						setTextInputFieldValue(f, buf)
 					}
 					e = &eventHandler{}
 				}
@@ -277,7 +306,7 @@ func (c *Context) numberFieldF(value *float64, step float64, digits int, idPart 
 				if updated {
 					buf := formatNumber(*value, digits)
 					if f := c.currentContainer().textInputTextField(id, false); f != nil {
-						f.SetTextAndSelection(buf, len(buf), len(buf))
+						setTextInputFieldValue(f, buf)
 					}
 					e = &eventHandler{}
 				}

--- a/textfield.go
+++ b/textfield.go
@@ -11,6 +11,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/hajimehoshi/ebiten/v2"
+	"github.com/hajimehoshi/ebiten/v2/exp/textinput"
 	"github.com/hajimehoshi/ebiten/v2/inpututil"
 )
 
@@ -41,8 +42,12 @@ func (c *Context) textFieldRaw(buf *string, id widgetID, opt option) (EventHandl
 
 		f := c.currentContainer().textInputTextField(id, true)
 		if c.focus == id {
+			// A freshly focused text input field still has its own cursor/selection state.
+			// Seed that state from the bound string before reading input so typing starts
+			// after any existing text instead of inserting at the beginning.
+			focusTextInputField(f, *buf)
+
 			// handle text input
-			f.Focus()
 			x := bounds.Min.X + c.style().padding + textWidth(*buf)
 			y := bounds.Min.Y + lineHeight()
 			handled, err := f.HandleInput(x, y)
@@ -58,7 +63,7 @@ func (c *Context) textFieldRaw(buf *string, id widgetID, opt option) (EventHandl
 				if inpututil.IsKeyJustPressed(ebiten.KeyBackspace) && len(*buf) > 0 {
 					_, size := utf8.DecodeLastRuneInString(*buf)
 					*buf = (*buf)[:len(*buf)-size]
-					f.SetTextAndSelection(*buf, len(*buf), len(*buf))
+					setTextInputFieldValue(f, *buf)
 				}
 				if inpututil.IsKeyJustPressed(ebiten.KeyEnter) {
 					e = &eventHandler{}
@@ -66,7 +71,9 @@ func (c *Context) textFieldRaw(buf *string, id widgetID, opt option) (EventHandl
 			}
 		} else {
 			if *buf != f.Text() {
-				f.SetTextAndSelection(*buf, len(*buf), len(*buf))
+				// Keep the cached text-input object in sync while it is unfocused so the
+				// next focus starts from the latest value and with the caret at the end.
+				setTextInputFieldValue(f, *buf)
 			}
 			if wasFocused {
 				e = &eventHandler{}
@@ -100,13 +107,30 @@ func (c *Context) textFieldRaw(buf *string, id widgetID, opt option) (EventHandl
 	})
 }
 
+func focusTextInputField(f *textinput.Field, value string) {
+	// Focus() does not rewrite the field's text or selection. If this field is being
+	// focused for the first time, its selection is still 0,0, so copy in the current
+	// value first and move the caret to the end.
+	if !f.IsFocused() && value != f.Text() {
+		setTextInputFieldValue(f, value)
+	}
+	f.Focus()
+}
+
+func setTextInputFieldValue(f *textinput.Field, value string) {
+	// Treat programmatic value changes the same way a user expects to keep typing:
+	// after loading text, place the caret at the end ready for appending.
+	f.SetTextAndSelection(value, len(value), len(value))
+}
+
 // SetTextFieldValue sets the value of the current text field.
+// The caret is moved to the end of the new text.
 //
 // If the last widget is not a text field, this function does nothing.
 func (c *Context) SetTextFieldValue(value string) {
 	_ = c.wrapEventHandlerAndError(func() (EventHandler, error) {
 		if f := c.currentContainer().textInputTextField(c.currentID, false); f != nil {
-			f.SetTextAndSelection(value, 0, 0)
+			setTextInputFieldValue(f, value)
 		}
 		return nil, nil
 	})
@@ -201,7 +225,7 @@ func (c *Context) numberField(value *int, step int, idPart string, opt option) (
 				if updated {
 					buf := fmt.Sprintf("%d", *value)
 					if f := c.currentContainer().textInputTextField(id, false); f != nil {
-						f.SetTextAndSelection(buf, len(buf), len(buf))
+						setTextInputFieldValue(f, buf)
 					}
 					e = &eventHandler{}
 				}
@@ -277,7 +301,7 @@ func (c *Context) numberFieldF(value *float64, step float64, digits int, idPart 
 				if updated {
 					buf := formatNumber(*value, digits)
 					if f := c.currentContainer().textInputTextField(id, false); f != nil {
-						f.SetTextAndSelection(buf, len(buf), len(buf))
+						setTextInputFieldValue(f, buf)
 					}
 					e = &eventHandler{}
 				}

--- a/textfield_test.go
+++ b/textfield_test.go
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2026 The Ebitengine Authors
+
+package debugui
+
+import (
+	"testing"
+
+	"github.com/hajimehoshi/ebiten/v2/exp/textinput"
+)
+
+func TestFocusTextInputFieldInitializesTextAndCaretAtEnd(t *testing.T) {
+	var f textinput.Field
+	t.Cleanup(f.Blur)
+
+	// This is the original regression: focusing a field with preloaded text must
+	// also initialize the internal selection so the next typed character appends.
+	focusTextInputField(&f, "hello")
+
+	if got, want := f.Text(), "hello"; got != want {
+		t.Fatalf("text = %q, want %q", got, want)
+	}
+	if !f.IsFocused() {
+		t.Fatal("field is not focused")
+	}
+
+	start, end := f.Selection()
+	if got, want := start, len("hello"); got != want {
+		t.Fatalf("selection start = %d, want %d", got, want)
+	}
+	if got, want := end, len("hello"); got != want {
+		t.Fatalf("selection end = %d, want %d", got, want)
+	}
+}
+
+func TestFocusTextInputFieldMovesCaretToEndWhenTextAlreadyMatches(t *testing.T) {
+	var f textinput.Field
+	t.Cleanup(f.Blur)
+
+	f.SetTextAndSelection("hello", 0, 0)
+
+	// Reopening a window can reuse the same cached field with the same text but
+	// an old selection. Focusing it again should still place the caret at the end.
+	focusTextInputField(&f, "hello")
+
+	start, end := f.Selection()
+	if got, want := start, len("hello"); got != want {
+		t.Fatalf("selection start = %d, want %d", got, want)
+	}
+	if got, want := end, len("hello"); got != want {
+		t.Fatalf("selection end = %d, want %d", got, want)
+	}
+}
+
+func TestSetTextFieldValueMovesCaretToEnd(t *testing.T) {
+	var c Context
+	cnt := &container{}
+	c.containerStack = []*container{cnt}
+
+	id := widgetID{}.push("field")
+	c.currentID = id
+	cnt.textInputTextField(id, true)
+
+	// SetTextFieldValue is used to replace the visible contents, so it must leave
+	// the hidden caret state at the end of the new text as well.
+	c.SetTextFieldValue("loaded")
+
+	f := cnt.textInputTextField(id, false)
+	if f == nil {
+		t.Fatal("field was not created")
+	}
+	if got, want := f.Text(), "loaded"; got != want {
+		t.Fatalf("text = %q, want %q", got, want)
+	}
+
+	start, end := f.Selection()
+	if got, want := start, len("loaded"); got != want {
+		t.Fatalf("selection start = %d, want %d", got, want)
+	}
+	if got, want := end, len("loaded"); got != want {
+		t.Fatalf("selection end = %d, want %d", got, want)
+	}
+}

--- a/textfield_test.go
+++ b/textfield_test.go
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2026 The Ebitengine Authors
+
+package debugui
+
+import (
+	"testing"
+
+	"github.com/hajimehoshi/ebiten/v2/exp/textinput"
+)
+
+func TestFocusTextInputFieldInitializesTextAndCaretAtEnd(t *testing.T) {
+	var f textinput.Field
+	t.Cleanup(f.Blur)
+
+	// This is the original regression: focusing a field with preloaded text must
+	// also initialize the internal selection so the next typed character appends.
+	focusTextInputField(&f, "hello")
+
+	if got, want := f.Text(), "hello"; got != want {
+		t.Fatalf("text = %q, want %q", got, want)
+	}
+	if !f.IsFocused() {
+		t.Fatal("field is not focused")
+	}
+
+	start, end := f.Selection()
+	if got, want := start, len("hello"); got != want {
+		t.Fatalf("selection start = %d, want %d", got, want)
+	}
+	if got, want := end, len("hello"); got != want {
+		t.Fatalf("selection end = %d, want %d", got, want)
+	}
+}
+
+func TestSetTextFieldValueMovesCaretToEnd(t *testing.T) {
+	var c Context
+	cnt := &container{}
+	c.containerStack = []*container{cnt}
+
+	id := widgetID{}.push("field")
+	c.currentID = id
+	cnt.textInputTextField(id, true)
+
+	// SetTextFieldValue is used to replace the visible contents, so it must leave
+	// the hidden caret state at the end of the new text as well.
+	c.SetTextFieldValue("loaded")
+
+	f := cnt.textInputTextField(id, false)
+	if f == nil {
+		t.Fatal("field was not created")
+	}
+	if got, want := f.Text(), "loaded"; got != want {
+		t.Fatalf("text = %q, want %q", got, want)
+	}
+
+	start, end := f.Selection()
+	if got, want := start, len("loaded"); got != want {
+		t.Fatalf("selection start = %d, want %d", got, want)
+	}
+	if got, want := end, len("loaded"); got != want {
+		t.Fatalf("selection end = %d, want %d", got, want)
+	}
+}


### PR DESCRIPTION
Fixes a `TextField` bug where typing into a field with an existing value could insert new characters at the start of the string instead of at the end. Fixes #50.

### Problem

`debugui` caches `textinput.Field` instances per widget ID. When a `TextField` was reopened or reused with preloaded text, the cached field could keep an old selection/insertion point from a previous editing session.

That meant the visible text was correct, but the next typed character could still be inserted at byte 0.

A related issue existed in `SetTextFieldValue`, which updated the field text but reset the selection to 0,0, leaving the next insertion at the start of the string.

### Fix

This change:

- resets the selection to the end of the current value whenever an unfocused text field becomes focused
- does this even when the text value already matches, because the cached field may still have stale caret state
- updates `SetTextFieldValue` to place the selection at the end of the new value
- reuses the same helper for other programmatic text updates in the text field code

### Tests

Adds regression tests covering:

- focusing a field with preloaded text
- focusing a reused field where the text is unchanged but the cached selection is stale
- `SetTextFieldValue` moving the caret to the end of the new text